### PR TITLE
Feature rejecting multi letter images

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ This app would take in multiple images of a persons handwriting and then analyze
 Create a folder in src\data with the name of the person whose writing you want to analyze. Place your image sample in this folder. Run the python code and when prompted type the name of the person and the name of the image file. The program will create a new folder in src\output with the name of the person whose writing has been analyzed. This folder will contain  image files of each character that was extracted. These images are sorted into folder alphabetically.
 
 # Main Developement Branch (dev)
-Development (dev) is the main development branch. The dev branch’s idea is to make changes in it and restrict the developers from making any changes in the master branch directly. Changes in the dev branch undergo reviews and, after testing, get merged with the master branch. 
+The Development branch (dev) is the main development branch. The dev branch’s idea is to make changes in it and restrict the developers from making any changes in the main branch directly. Changes in the dev branch undergo reviews and, after testing, get merged with the main branch. 
 Further Explaination of dev Branch and GitHub Repository Conventions:
 https://codingsight.com/git-branching-naming-convention-best-practices/


### PR DESCRIPTION
- I used some basic stuff I learned in AP Statistics to reject letter-images with widths greater than 1.9 standard deviations from the mean width in the sample. This in effect, finds and rejects letter-images that are abnormally wide, meaning they likely have multiple letters crammed in. 
- I Tested my code rigorously, and found and it removes 100% of all multi-letter images, while only removing 4 correct letter-images (from all 3 pangram samples combined: pangram/uppercase/lowercase).
- Because of the way this code works it will likely be necessary that the user only enter all caps or all lowercase (but it looks like we're already doing this)